### PR TITLE
make reset/pause/restart scan work correctly

### DIFF
--- a/apps/api/src/api.controller.ts
+++ b/apps/api/src/api.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Delete, Get, HttpStatus, Logger, Post, Put } from '@nestjs/common';
-import { ApiBody, ApiOkResponse } from '@nestjs/swagger';
+import { Body, Controller, Delete, Get, HttpStatus, Logger, Post, Put, Query } from '@nestjs/common';
+import { ApiBody, ApiOkResponse, ApiQuery } from '@nestjs/swagger';
 import { ApiService } from './api.service';
 import { ResetScannerDto, ContentSearchRequestDto } from '../../../libs/common/src';
 import { ChainWatchOptionsDto } from '../../../libs/common/src/dtos/chain.watch.dto';
@@ -27,8 +27,7 @@ export class ApiController {
     type: ResetScannerDto,
   })
   resetScanner(@Body() resetScannerDto: ResetScannerDto) {
-    let blockNumber = 0;
-    return this.apiService.setLastSeenBlockNumber(blockNumber);
+    return this.apiService.resetScanner(resetScannerDto);
   }
 
   @Post('setWatchOptions')
@@ -46,8 +45,15 @@ export class ApiController {
   }
 
   @Post('startScanner')
-  startScanner() {
-    return this.apiService.resumeScanner();
+  @ApiQuery({
+    name: 'immediate',
+    description: 'immediate: whether to resume scan immediately (true), or wait until next scheduled scan (false)',
+    type: 'boolean',
+    required: false,
+  })
+  startScanner(@Query('immediate') immediate?: boolean) {
+    this.logger.debug(`Resuming scan; immediate=${immediate}`);
+    return this.apiService.resumeScanner(immediate);
   }
 
   @Put('search')

--- a/apps/api/src/api.controller.ts
+++ b/apps/api/src/api.controller.ts
@@ -27,7 +27,8 @@ export class ApiController {
     type: ResetScannerDto,
   })
   resetScanner(@Body() resetScannerDto: ResetScannerDto) {
-    return this.apiService.setLastSeenBlockNumber(BigInt(resetScannerDto.blockNumber ?? 0n));
+    let blockNumber = 0;
+    return this.apiService.setLastSeenBlockNumber(blockNumber);
   }
 
   @Post('setWatchOptions')

--- a/apps/api/src/api.service.ts
+++ b/apps/api/src/api.service.ts
@@ -22,9 +22,9 @@ export class ApiService {
     this.logger = new Logger(this.constructor.name);
   }
 
-  public setLastSeenBlockNumber(blockNumber: bigint) {
+  public setLastSeenBlockNumber(blockNumber: number) {
     this.logger.warn(`Setting last seen block number to ${blockNumber}`);
-    return this.redis.setex(LAST_SEEN_BLOCK_NUMBER_SCANNER_KEY, RedisUtils.STORAGE_EXPIRE_UPPER_LIMIT_SECONDS, blockNumber.toString());
+    return this.redis.setex(LAST_SEEN_BLOCK_NUMBER_SCANNER_KEY, RedisUtils.STORAGE_EXPIRE_UPPER_LIMIT_SECONDS, blockNumber);
   }
 
   public async setWatchOptions(watchOptions: ChainWatchOptionsDto) {

--- a/apps/api/src/api.service.ts
+++ b/apps/api/src/api.service.ts
@@ -3,12 +3,13 @@ import { InjectRedis } from '@songkeys/nestjs-redis';
 import Redis from 'ioredis';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
-import { ContentSearchRequestDto, REQUEST_QUEUE_NAME, calculateJobId } from '../../../libs/common/src';
+import { ContentSearchRequestDto, REQUEST_QUEUE_NAME, ResetScannerDto, calculateJobId } from '../../../libs/common/src';
 import { ScannerService } from '../../../libs/common/src/scanner/scanner';
-import { EVENTS_TO_WATCH_KEY, LAST_SEEN_BLOCK_NUMBER_SCANNER_KEY, REGISTERED_WEBHOOK_KEY } from '../../../libs/common/src/constants';
+import { EVENTS_TO_WATCH_KEY, REGISTERED_WEBHOOK_KEY } from '../../../libs/common/src/constants';
 import { ChainWatchOptionsDto } from '../../../libs/common/src/dtos/chain.watch.dto';
 import { WebhookRegistrationDto } from '../../../libs/common/src/dtos/subscription.webhook.dto';
 import * as RedisUtils from '../../../libs/common/src/utils/redis';
+import { IScanReset } from '../../../libs/common/src/interfaces/scan-reset.interface';
 
 @Injectable()
 export class ApiService {
@@ -22,11 +23,6 @@ export class ApiService {
     this.logger = new Logger(this.constructor.name);
   }
 
-  public setLastSeenBlockNumber(blockNumber: number) {
-    this.logger.warn(`Setting last seen block number to ${blockNumber}`);
-    return this.redis.setex(LAST_SEEN_BLOCK_NUMBER_SCANNER_KEY, RedisUtils.STORAGE_EXPIRE_UPPER_LIMIT_SECONDS, blockNumber);
-  }
-
   public async setWatchOptions(watchOptions: ChainWatchOptionsDto) {
     this.logger.warn(`Setting watch options to ${JSON.stringify(watchOptions)}`);
     const currentWatchOptions = await this.redis.get(EVENTS_TO_WATCH_KEY);
@@ -36,12 +32,16 @@ export class ApiService {
 
   public pauseScanner() {
     this.logger.warn('Pausing scanner');
-    return this.scannerService.pauseScanner();
+    this.scannerService.pauseScanner();
   }
 
-  public resumeScanner() {
+  public resumeScanner(immediate = false) {
     this.logger.warn('Resuming scanner');
-    return this.scannerService.resumeScanner();
+    this.scannerService.resumeScanner(immediate);
+  }
+
+  public async resetScanner(resetScannerOptions: IScanReset) {
+    await this.scannerService.resetScan(resetScannerOptions);
   }
 
   public async searchContent(contentSearchRequestDto: ContentSearchRequestDto) {

--- a/libs/common/src/blockchain/blockchain.service.ts
+++ b/libs/common/src/blockchain/blockchain.service.ts
@@ -71,8 +71,8 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
     return (await this.apiPromise.rpc.chain.getFinalizedHead()) as BlockHash;
   }
 
-  public async getLatestFinalizedBlockNumber(): Promise<bigint> {
-    return (await this.apiPromise.rpc.chain.getBlock()).block.header.number.toBigInt();
+  public async getLatestFinalizedBlockNumber(): Promise<number> {
+    return (await this.apiPromise.rpc.chain.getBlock()).block.header.number.toNumber();
   }
 
   public async getBlockNumberForHash(hash: string): Promise<number | undefined> {

--- a/libs/common/src/config/config.service.ts
+++ b/libs/common/src/config/config.service.ts
@@ -37,8 +37,8 @@ export class ConfigService {
     return this.nestConfigService.get('FREQUENCY_URL')!;
   }
 
-  public get startingBlock(): string {
-    return this.nestConfigService.get('STARTING_BLOCK')!;
+  public get startingBlock(): number | undefined {
+    return this.nestConfigService.get<number>('STARTING_BLOCK')!;
   }
 
   public get blockchainScanIntervalMinutes(): number {

--- a/libs/common/src/config/env.config.ts
+++ b/libs/common/src/config/env.config.ts
@@ -10,7 +10,7 @@ export const configModuleOptions: ConfigModuleOptions = {
     IPFS_BASIC_AUTH_SECRET: Joi.string().allow('').default(''),
     REDIS_URL: Joi.string().uri().required(),
     FREQUENCY_URL: Joi.string().uri().required(),
-    STARTING_BLOCK: Joi.number().min(1).default(1),
+    STARTING_BLOCK: Joi.number().min(1),
     BLOCKCHAIN_SCAN_INTERVAL_MINUTES: Joi.number()
       .min(1)
       .default(3 * 60),

--- a/libs/common/src/dtos/announcement.dto.ts
+++ b/libs/common/src/dtos/announcement.dto.ts
@@ -2,7 +2,7 @@
  * File name should always end with `.dto.ts` for swagger metadata generator to get picked up
  */
 // eslint-disable-next-line max-classes-per-file
-import { IsEnum, IsHexadecimal, IsInt, IsNotEmpty, IsString, Matches, Max, MaxLength, Min, MinLength, ValidateNested } from 'class-validator';
+import { IsEnum, IsInt, IsNotEmpty, IsString, Matches, Max, Min, MinLength, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { NoteActivityDto, ProfileActivityDto } from './activity.dto';
 import { DSNP_CONTENT_HASH_REGEX, DSNP_CONTENT_URI_REGEX, DSNP_EMOJI_REGEX } from './validation.dto';

--- a/libs/common/src/dtos/common.dto.ts
+++ b/libs/common/src/dtos/common.dto.ts
@@ -3,7 +3,8 @@
  */
 // eslint-disable-next-line max-classes-per-file
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumberString } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsNumberString, IsOptional, IsPositive, isPositive } from 'class-validator';
+import { IScanReset } from '../interfaces/scan-reset.interface';
 
 export class DsnpUserIdParam {
   @IsNotEmpty()
@@ -24,9 +25,17 @@ export class FilesUploadDto {
   files: any[];
 }
 
-export class ResetScannerDto {
-  @ApiProperty({ type: 'number', description: 'The block number to reset the scanner to', example: 0 })
+export class ResetScannerDto implements IScanReset {
+  @IsOptional()
+  @IsNumber()
+  @IsPositive()
+  @ApiProperty({ required: false, type: 'number', description: 'The block number to reset the scanner to', example: 0 })
   blockNumber: number;
+
+  @IsOptional()
+  @IsNumber()
+  @ApiProperty({ required: false, type: 'number', description: 'Number of blocks to rewind the scanner to (from `blockNumber` if supplied; else latest block' })
+  rewindOffset: number;
 }
 
 // eslint-disable-next-line no-shadow

--- a/libs/common/src/dtos/common.dto.ts
+++ b/libs/common/src/dtos/common.dto.ts
@@ -3,7 +3,7 @@
  */
 // eslint-disable-next-line max-classes-per-file
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsNumberString, IsOptional, IsPositive, isPositive } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsNumber, IsNumberString, IsOptional, IsPositive, isPositive } from 'class-validator';
 import { IScanReset } from '../interfaces/scan-reset.interface';
 
 export class DsnpUserIdParam {
@@ -30,12 +30,17 @@ export class ResetScannerDto implements IScanReset {
   @IsNumber()
   @IsPositive()
   @ApiProperty({ required: false, type: 'number', description: 'The block number to reset the scanner to', example: 0 })
-  blockNumber: number;
+  blockNumber?: number;
 
   @IsOptional()
   @IsNumber()
-  @ApiProperty({ required: false, type: 'number', description: 'Number of blocks to rewind the scanner to (from `blockNumber` if supplied; else latest block' })
-  rewindOffset: number;
+  @ApiProperty({ required: false, type: 'number', description: 'Number of blocks to rewind the scanner to (from `blockNumber` if supplied; else from latest block', example: 100 })
+  rewindOffset?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({ required: false, type: 'boolean', description: 'Whether to schedule the new scan immediately or wait for the next scheduled interval', example: true })
+  immediate?: boolean;
 }
 
 // eslint-disable-next-line no-shadow

--- a/libs/common/src/interfaces/scan-reset.interface.ts
+++ b/libs/common/src/interfaces/scan-reset.interface.ts
@@ -1,0 +1,4 @@
+export interface IScanReset {
+    blockNumber?: number;
+    rewindOffset?: number;
+}

--- a/libs/common/src/interfaces/scan-reset.interface.ts
+++ b/libs/common/src/interfaces/scan-reset.interface.ts
@@ -1,4 +1,5 @@
 export interface IScanReset {
     blockNumber?: number;
     rewindOffset?: number;
+    immediate?: boolean;
 }

--- a/libs/common/src/scanner/scanner.ts
+++ b/libs/common/src/scanner/scanner.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-await-in-loop */
 import '@frequency-chain/api-augment';
-import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import Redis from 'ioredis';
 import { InjectRedis } from '@songkeys/nestjs-redis';
@@ -17,14 +17,15 @@ import * as RedisUtils from '../utils/redis';
 import { ChainEventProcessorService } from '../blockchain/chain-event-processor.service';
 import { IScanReset } from '../interfaces/scan-reset.interface';
 
+const INTERVAL_SCAN_NAME = 'intervalScan';
+
 @Injectable()
-export class ScannerService implements OnApplicationBootstrap {
+export class ScannerService implements OnApplicationBootstrap, OnApplicationShutdown {
   private readonly logger: Logger;
 
   private scanInProgress = false;
-
   private paused = false;
-  private currentScanPromise: Promise<void> = Promise.resolve();
+  private scanResetBlockNumber: number | undefined;
 
   constructor(
     private readonly configService: ConfigService,
@@ -38,49 +39,46 @@ export class ScannerService implements OnApplicationBootstrap {
   }
 
   async onApplicationBootstrap() {
-    const startingBlock = Number(this.configService.startingBlock) - 1;
-    this.setLastSeenBlockNumber(startingBlock);
-    this.scheduleInitialScan();
-    this.scheduleBlockchainScan();
-  }
+    const startingBlock = this.configService.startingBlock;
+    if (startingBlock) {
+      this.logger.log(`Setting initial scan block to ${startingBlock}`);
+      this.setLastSeenBlockNumber(startingBlock - 1);
+    }
+    setImmediate(() => this.scan());
 
-  private scheduleInitialScan() {
-    const initialTimeout = setTimeout(() => this.scan(), 0);
-    this.schedulerRegistry.addTimeout('initialScan', initialTimeout);
-  }
-
-  private scheduleBlockchainScan() {
     const scanInterval = this.configService.blockchainScanIntervalMinutes * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND;
-
-    const interval = setInterval(() => this.scan(), scanInterval);
-    this.schedulerRegistry.addInterval('blockchainScan', interval);
+    this.schedulerRegistry.addInterval(INTERVAL_SCAN_NAME, setInterval(() => this.scan(), scanInterval));
   }
 
-  public async pauseScanner() {
+  onApplicationShutdown(_signal?: string | undefined) {
+    const interval = this.schedulerRegistry.getInterval(INTERVAL_SCAN_NAME);
+    clearInterval(interval);
+  }
+
+  public pauseScanner() {
     this.logger.debug('Pausing scanner');
     this.paused = true;
   }
 
-  public async resumeScanner() {
+  public resumeScanner(immediate = false) {
     this.logger.debug('Resuming scanner');
     this.paused = false;
+    if (immediate) {
+      setImmediate(() => this.scan());
+    }
   }
 
-  public async resetScan({ blockNumber, rewindOffset }: IScanReset) {
+  public async resetScan({ blockNumber, rewindOffset, immediate }: IScanReset) {
     this.pauseScanner();
     let targetBlock = blockNumber ?? await this.blockchainService.getLatestFinalizedBlockNumber();
     targetBlock -= rewindOffset ? Math.abs(rewindOffset) : 0;
     targetBlock = Math.max(targetBlock, 1);
-    this.setLastSeenBlockNumber(targetBlock - 1);
-    this.resumeScanner();
-  }
-
-  public get currentScan(): Promise<void> {
-    return this.currentScanPromise;
+    this.scanResetBlockNumber = targetBlock;
+    this.logger.log(`Resetting scan to block #${targetBlock}`);
+    this.resumeScanner(immediate);
   }
 
   async scan() {
-    let resolveCurrentScan = () => {};
     try {
       this.logger.debug('Starting scanner');
 
@@ -89,18 +87,7 @@ export class ScannerService implements OnApplicationBootstrap {
         return;
       }
 
-      if (this.paused) {
-        this.logger.debug('Scanner is paused');
-        return;
-      }
-      let queueSize = await this.ipfsQueue.count();
-
-      if (queueSize > 0) {
-        this.logger.log('Deferring next blockchain scan until queue is empty');
-        return;
-      }
       const registeredWebhook = await this.cache.get(REGISTERED_WEBHOOK_KEY);
-
       if (!registeredWebhook) {
         this.logger.log('No registered webhooks; no scan performed.');
         return;
@@ -108,48 +95,58 @@ export class ScannerService implements OnApplicationBootstrap {
       const chainWatchFilters = await this.cache.get(EVENTS_TO_WATCH_KEY);
       const eventsToWatch: ChainWatchOptionsDto = chainWatchFilters ? JSON.parse(chainWatchFilters) : { msa_ids: [], schemaIds: [] };
 
-      let lastScannedBlock = await this.getLastSeenBlockNumber();
-      const currentBlockNumber = lastScannedBlock + 1;
-      let currentBlockHash = await this.blockchainService.getBlockHash(currentBlockNumber);
-
-      if (currentBlockHash.isEmpty) {
-        this.logger.log('No new blocks to read; no scan performed.');
-        this.scanInProgress = false;
-        return;
-      }
-
       this.scanInProgress = true;
-      this.currentScanPromise = new Promise((resolve) => {
-        resolveCurrentScan = resolve;
-      });
-      this.logger.log(`Starting scan from block #${currentBlockNumber} (${currentBlockHash})`);
 
-      while (!this.paused && !currentBlockHash.isEmpty && queueSize < this.configService.queueHighWater) {
-        const messages = await this.chainEventProcessor.getMessagesInBlock(lastScannedBlock, eventsToWatch);
+      let first = true;
+      while (true) {
+        if (this.paused) {
+          this.logger.log('Scan paused');
+          break;
+        }
+
+        const queueSize = await this.ipfsQueue.count();
+        if (queueSize > this.configService.queueHighWater) {
+          this.logger.log('Queue soft limit reached; pausing scan until next interval');
+          break;
+        }
+
+        const currentBlockNumber = await this.getNextBlockNumber();
+        const currentBlockHash = await this.blockchainService.getBlockHash(currentBlockNumber);
+        if (currentBlockHash.isEmpty) {
+          this.logger.log(`No new blocks to scan @ block number ${currentBlockNumber}; pausing scan until next interval`);
+          break;
+        }
+
+        if (first) {
+          this.logger.log(`Starting scan @ block # ${currentBlockNumber} (${currentBlockHash})`);
+          first = false;
+        }
+
+        const messages = await this.chainEventProcessor.getMessagesInBlock(currentBlockNumber, eventsToWatch);
         if (messages.length > 0) {
           this.logger.debug(`Found ${messages.length} messages to process`);
         }
         await this.chainEventProcessor.queueIPFSJobs(messages, this.ipfsQueue);
-        await this.saveProgress(lastScannedBlock);
-        lastScannedBlock += 1;
-        currentBlockHash = await this.blockchainService.getBlockHash(lastScannedBlock);
-        queueSize = await this.ipfsQueue.count();
-      }
-      if (currentBlockHash.isEmpty) {
-        this.logger.log(`Scan reached end-of-chain at block ${lastScannedBlock - 1}`);
-      } else if (queueSize > this.configService.queueHighWater) {
-        this.logger.log('Queue soft limit reached; pausing scan until next iteration');
+        await this.saveProgress(currentBlockNumber);
       }
     } catch (err) {
       this.logger.error(err);
     } finally {
       this.scanInProgress = false;
-      resolveCurrentScan();
     }
   }
 
-  private async getLastSeenBlockNumber(): Promise<number> {
-    return Number((await this.cache.get(LAST_SEEN_BLOCK_NUMBER_SCANNER_KEY)) ?? 0);
+  private async getNextBlockNumber(): Promise<number> {
+    let nextBlock: number;
+    if (this.scanResetBlockNumber) {
+      await this.setLastSeenBlockNumber(this.scanResetBlockNumber - 1);
+      nextBlock = this.scanResetBlockNumber;
+      this.scanResetBlockNumber = undefined;
+    } else {
+      nextBlock = (Number(await this.cache.get(LAST_SEEN_BLOCK_NUMBER_SCANNER_KEY)) ?? 0) + 1;
+    }
+
+    return nextBlock;
   }
 
   private async saveProgress(blockNumber: number): Promise<void> {


### PR DESCRIPTION
# Description
Makes changing the current block number while the scan is paused work correctly.
* Adds additional request options to `resetScan` endpoint:
    * `rewindOffset`: number; indicates number of blocks to rewind from either end of chain or block number in request
    * `immediate`: boolean; indicates whether to start the scan immediately from the new position, or allow it to take effect at the next scheduled interval
    
Refactors the scan loop a bit to make more compact & readable, as well as to be able to honor scan reset requests even if a scan is in-progress.